### PR TITLE
Remove API gateway widgets.

### DIFF
--- a/src/dashboards/configs/default.json
+++ b/src/dashboards/configs/default.json
@@ -51,16 +51,6 @@
         }
       },
       {
-        "title": "API Requests",
-        "service": "api-gw",
-        "metric": "requests",
-        "display": "time-series",
-        "coordinates": {
-          "x": 14, "y": 6,
-          "width": 10, "height": 6
-        }
-      },
-      {
         "title": "Throttles",
         "service": "lambda",
         "metric": "throttles",
@@ -78,16 +68,6 @@
         "coordinates": {
           "x": 8, "y": 12,
           "width": 6, "height": 6
-        }
-      },
-      {
-        "title": "API Latency",
-        "service": "api-gw",
-        "metric": "latency",
-        "display": "time-series",
-        "coordinates": {
-          "x": 14, "y": 12,
-          "width": 10, "height": 6
         }
       }
     ]

--- a/src/dashboards/configs/vertical.json
+++ b/src/dashboards/configs/vertical.json
@@ -99,46 +99,6 @@
           "x": 10, "y": 24,
           "width": 10, "height": 6
         }
-      },
-      {
-        "title": "API Latency",
-        "service": "api-gw",
-        "metric": "latency",
-        "display": "time-series",
-        "coordinates": {
-          "x": 0, "y": 30,
-          "width": 10, "height": 6
-        }
-      },
-      {
-        "title": "API Latency Average",
-        "service": "api-gw",
-        "metric": "latency",
-        "display": "numbers",
-        "coordinates": {
-          "x": 10, "y": 30,
-          "width": 10, "height": 6
-        }
-      },
-      {
-        "title": "API Requests",
-        "service": "api-gw",
-        "metric": "requests",
-        "display": "time-series",
-        "coordinates": {
-          "x": 0, "y": 36,
-          "width": 10, "height": 6
-        }
-      },
-      {
-        "title": "API Requests",
-        "service": "api-gw",
-        "metric": "requests",
-        "display": "numbers",
-        "coordinates": {
-          "x": 10, "y": 36,
-          "width": 10, "height": 6
-        }
       }
     ]
 }


### PR DESCRIPTION
## Remove API Gateway Widgets:

As Event Engine is using single API Gateway, widgets by service name are not going to work. Hence removing them from the config.

